### PR TITLE
Instrument LoggerJniCallback Logv call with timing

### DIFF
--- a/java/rocksjni/loggerjnicallback.cc
+++ b/java/rocksjni/loggerjnicallback.cc
@@ -175,7 +175,7 @@ void LoggerJniCallback::Logv(const InfoLogLevel log_level, const char* format,
     auto diff =
         std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
-    std::cout << std::to_string(diff.count()) << "\n";
+    std::cout << (std::to_string(diff.count()) + "\n");
   }
 }
 

--- a/java/rocksjni/loggerjnicallback.cc
+++ b/java/rocksjni/loggerjnicallback.cc
@@ -135,6 +135,8 @@ void LoggerJniCallback::Logv(const InfoLogLevel log_level, const char* format,
     assert(format != nullptr);
     const std::unique_ptr<char[]> msg = format_str(format, ap);
 
+    auto start = std::chrono::steady_clock::now();
+
     // pass msg to java callback handler
     jboolean attached_thread = JNI_FALSE;
     JNIEnv* env = getJniEnv(&attached_thread);
@@ -168,6 +170,12 @@ void LoggerJniCallback::Logv(const InfoLogLevel log_level, const char* format,
 
     env->DeleteLocalRef(jmsg);
     releaseJniEnv(attached_thread);
+
+    auto end = std::chrono::steady_clock::now();
+    auto diff =
+        std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    std::cout << std::to_string(diff.count()) << "\n";
   }
 }
 


### PR DESCRIPTION
- Wrap the calls that attach/detach from the JVM in `LoggerJniCallback`'s `Logv` call with a timer
- Print the time taken to `stdout`