### PR TITLE
Implement setNativeLogger to configure a RocksDB Native logger from Java

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -200,6 +200,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/MutableOptionValue.java
   src/main/java/org/rocksdb/NativeComparatorWrapper.java
   src/main/java/org/rocksdb/NativeLibraryLoader.java
+  src/main/java/org/rocksdb/NativeLoggerType.java
   src/main/java/org/rocksdb/OperationStage.java
   src/main/java/org/rocksdb/OperationType.java
   src/main/java/org/rocksdb/OptimisticTransactionDB.java

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -1095,6 +1095,37 @@ void Java_org_rocksdb_Options_setLogger(JNIEnv*, jobject, jlong jhandle,
 
 /*
  * Class:     org_rocksdb_Options
+ * Method:    setNativeLogger
+ * Signature: (JB)V
+ */
+void Java_org_rocksdb_Options_setNativeLogger(JNIEnv*, jobject, jlong jhandle,
+                                              jbyte jnative_logger_type) {
+  auto log_level =
+      reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->info_log_level;
+
+  switch (jnative_logger_type) {
+    // Null logger
+    case 0x0:
+      reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->info_log =
+          std::make_shared<ROCKSDB_NAMESPACE::NullLogger>();
+      break;
+
+    // Stderr logger
+    case 0x1:
+      reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->info_log =
+          std::make_shared<ROCKSDB_NAMESPACE::StderrLogger>(log_level);
+      break;
+
+    default:
+      ROCKSDB_NAMESPACE::IllegalArgumentExceptionJni::ThrowNew(
+          env,
+          std::string("Setting native logger is not supported for " +
+                      "logger type " + static_cast<char>(jnative_logger_type)));
+  }
+}
+
+/*
+ * Class:     org_rocksdb_Options
  * Method:    setInfoLogLevel
  * Signature: (JB)V
  */

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -37,6 +37,8 @@
 #include "rocksjni/portal.h"
 #include "rocksjni/statisticsjni.h"
 #include "rocksjni/table_filter_jnicallback.h"
+#include "test_util/testutil.h"
+#include "util/stderr_logger.h"
 #include "utilities/merge_operators.h"
 
 /*
@@ -1098,16 +1100,17 @@ void Java_org_rocksdb_Options_setLogger(JNIEnv*, jobject, jlong jhandle,
  * Method:    setNativeLogger
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Options_setNativeLogger(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setNativeLogger(JNIEnv* env, jobject,
+                                              jlong jhandle,
                                               jbyte jnative_logger_type) {
   auto log_level =
       reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->info_log_level;
 
   switch (jnative_logger_type) {
-    // Null logger
+    // Null logger (from test_util)
     case 0x0:
       reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->info_log =
-          std::make_shared<ROCKSDB_NAMESPACE::NullLogger>();
+          std::make_shared<ROCKSDB_NAMESPACE::test::NullLogger>();
       break;
 
     // Stderr logger
@@ -1116,11 +1119,12 @@ void Java_org_rocksdb_Options_setNativeLogger(JNIEnv*, jobject, jlong jhandle,
           std::make_shared<ROCKSDB_NAMESPACE::StderrLogger>(log_level);
       break;
 
+    // Shouldn't happen, since this should only be called from Java using
+    // NativeLoggerType.
     default:
       ROCKSDB_NAMESPACE::IllegalArgumentExceptionJni::ThrowNew(
-          env,
-          std::string("Setting native logger is not supported for " +
-                      "logger type " + static_cast<char>(jnative_logger_type)));
+          env, std::string("Setting native logger is not supported for type ") +
+                   static_cast<char>(jnative_logger_type));
   }
 }
 

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -220,6 +220,13 @@ public class DBOptions extends RocksObject
   }
 
   @Override
+  public Options setNativeLogger(final NativeLoggerType nativeLoggerType) {
+    assert(isOwningHandle());
+    setNativeLogger(nativeHandle_, nativeLoggerType.getValue());
+    return this;
+  }
+
+  @Override
   public DBOptions setInfoLogLevel(
       final InfoLogLevel infoLogLevel) {
     assert(isOwningHandle());
@@ -1277,6 +1284,8 @@ public class DBOptions extends RocksObject
       final long sstFileManagerHandle);
   private native void setLogger(long handle,
       long loggerHandle);
+  private native void setNativeLogger(long handle,
+      byte nativeLoggerType);
   private native void setInfoLogLevel(long handle, byte logLevel);
   private native byte infoLogLevel(long handle);
   private native void setMaxOpenFiles(long handle, int maxOpenFiles);

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -220,7 +220,7 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public Options setNativeLogger(final NativeLoggerType nativeLoggerType) {
+  public DBOptions setNativeLogger(final NativeLoggerType nativeLoggerType) {
     assert(isOwningHandle());
     setNativeLogger(nativeHandle_, nativeLoggerType.getValue());
     return this;

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -191,6 +191,16 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
   T setLogger(Logger logger);
 
   /**
+   * <p>Sets RocksDB logger to be the specified native logger.
+   * This should not be used in conjunction with setLogger, which
+   * sets the RocksDB to be a Java logger.</p>
+   * 
+   * @param nativeLoggerType {@link NativeLoggerType} instance.
+   * @return the instance of the current object.
+   */
+  T setNativeLogger(NativeLoggerType nativeLoggerType);
+
+  /**
    * <p>Sets the RocksDB log level. Default level is INFO</p>
    *
    * @param infoLogLevel log level to set.

--- a/java/src/main/java/org/rocksdb/NativeLoggerType.java
+++ b/java/src/main/java/org/rocksdb/NativeLoggerType.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import org.rocksdb.RocksDB;
+
+/**
+ * Enum NativeLoggerType
+ * 
+ * <p>
+ * RocksDB can log in two ways: to a Java logger that you supply,
+ * or via a native logger. The specific native logger can be specified
+ * using this enumeration.
+ * 
+ * This cannot be used in conjunction with setLogger.
+ */
+public enum NativeLoggerType {
+  // In the future, we can add support for Auto-roll, Env logger, or
+  // Win logger.
+  DEVNULL((byte) 0x0),
+  STDERR((byte) 0x1);
+
+  private final byte value;
+
+  NativeLoggerType(final byte value) {
+    this.value = value;
+  }
+
+  /**
+   * Get the internal representation value.
+   *
+   * @return the internal representation value.
+   */
+  public byte getValue() {
+    return value;
+  }
+
+  /**
+   * Get the NativeLoggerType from the internal representation value.
+   *
+   * @param value the internal representation value.
+   *
+   * @return the NativeLoggerType
+   *
+   * @throws IllegalArgumentException if the value does not match a
+   *                                  NativeLoggerType
+   */
+  static NativeLoggerType fromValue(final byte value)
+      throws IllegalArgumentException {
+    for (final NativeLoggerType loggerType : NativeLoggerType.values()) {
+      if (loggerType.value == value) {
+        return loggerType;
+      }
+    }
+    throw new IllegalArgumentException("Unknown value for NativeLoggerType: "
+        + value);
+  }
+}

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -1252,6 +1252,13 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options setNativeLogger(final NativeLoggerType nativeLoggerType) {
+    assert(isOwningHandle());
+    setNativeLogger(nativeHandle_, nativeLoggerType.getValue());
+    return this;
+  }
+
+  @Override
   public Options setInfoLogLevel(final InfoLogLevel infoLogLevel) {
     assert(isOwningHandle());
     setInfoLogLevel(nativeHandle_, infoLogLevel.getValue());
@@ -2152,6 +2159,8 @@ public class Options extends RocksObject
       final long sstFileManagerHandle);
   private native void setLogger(long handle,
       long loggerHandle);
+  private native void setNativeLogger(long handle,
+      byte nativeHandleType);
   private native void setInfoLogLevel(long handle, byte logLevel);
   private native byte infoLogLevel(long handle);
   private native void setMaxOpenFiles(long handle, int maxOpenFiles);


### PR DESCRIPTION
Pending items (for subsequent PRs):

1. Figure out a path forward for Auto-roll, Env, and Win loggers (probably can use `CreateLoggerFromOptions` or `FileSystem::NewLogger`). However, those respectively take a `dbname` and a `fname`. It's unclear the best way to pass those from Java to C++. We could use a new option (or two), but then we'll clutter the `Options` with a Java-specific option. Another option is to add arguments to `setNativeLogger`, but having an argument per new option (i.e. one for `dbname` and `fname`) gets verbose. I think the latter is better, though, so that we don't clutter the `Options` of a mostly-native library. I'd appreciate a discussion of this tradeoff below.
2. We'd also like to include the `dbname` in the StderrLogger, which means that the StderrLogger needs to be passed that when it is initialized. This likely will be easy to implement once we reach an agreement on decision (1).